### PR TITLE
Fix Module not found Error for es6

### DIFF
--- a/index.es6.js
+++ b/index.es6.js
@@ -1,4 +1,4 @@
-import metadata from './metadata.min'
+import metadata from './metadata.min.js'
 
 import parseCustom, { get_number_type as getNumberTypeCustom } from './es6/parse'
 import formatCustom from './es6/format'


### PR DESCRIPTION
- Fix `./metadata.min` module not found error for es6 import. It’s better to explicitly import non-js module/file with file extension. i.e. `import ‘./metadata.min.json’`